### PR TITLE
Streamline register org

### DIFF
--- a/actions/register_org.py
+++ b/actions/register_org.py
@@ -9,7 +9,7 @@ __all__ = [
 
 
 class AddOrgAction(BaseGithubAction):
-    def run(self, user, url, token, github_type, repositories, event_type_whitelist):
+    def run(self, user, url, token, repositories, event_type_whitelist):
 
         client = Client()
         gitorgs = client.keys.get_by_name(name='git-orgs', decrypt=True)
@@ -17,6 +17,7 @@ class AddOrgAction(BaseGithubAction):
             dict=json.loads(gitorgs.value)
         else:
             dict={}
+        github_type = 'online' if url.find('github.com') > -1 else 'enterprise'
         org = {'user': user, 'url': url, 'token': token, 'type': github_type, 'repositories': repositories, 'event_type_whitelist': event_type_whitelist}
         dict[user+'|'+url]=org
         gitorgs=json.dumps(dict)

--- a/actions/register_org.py
+++ b/actions/register_org.py
@@ -9,7 +9,7 @@ __all__ = [
 
 
 class AddOrgAction(BaseGithubAction):
-    def run(self, user, url, token, repositories, event_type_whitelist):
+    def run(self, user, url, token, github_type, repositories, event_type_whitelist):
 
         client = Client()
         gitorgs = client.keys.get_by_name(name='git-orgs', decrypt=True)
@@ -17,7 +17,6 @@ class AddOrgAction(BaseGithubAction):
             dict=json.loads(gitorgs.value)
         else:
             dict={}
-        github_type = 'online' if url.find('github.com') > -1 else 'enterprise'
         org = {'user': user, 'url': url, 'token': token, 'type': github_type, 'repositories': repositories, 'event_type_whitelist': event_type_whitelist}
         dict[user+'|'+url]=org
         gitorgs=json.dumps(dict)

--- a/actions/register_org.yaml
+++ b/actions/register_org.yaml
@@ -10,10 +10,6 @@ parameters:
     type: "string"
     required: true
     description: "base API url."
-  github_type:
-    type: "string"
-    required: true
-    description: "type of github: online or enterprise"
   token:
     type: "string"
     required: true

--- a/actions/register_org.yaml
+++ b/actions/register_org.yaml
@@ -8,8 +8,15 @@ entry_point: "register_org.py"
 parameters:
   url:
     type: "string"
-    required: true
+    required: false
     description: "base API url."
+  github_type:
+    type: "string"
+    enum:
+      - "online"
+      - "enterprise"
+    required: true
+    description: "type of github: online or enterprise"
   token:
     type: "string"
     required: true


### PR DESCRIPTION
Signed-off-by: Andrew Mak <makandre@ca.ibm.com>

~I want to streamline to params to `register_org`; we don't need the `github_type` because we can infer it from the `url`~