### PR TITLE
list_orgs without user name

### DIFF
--- a/actions/delete_registered_org.py
+++ b/actions/delete_registered_org.py
@@ -19,7 +19,10 @@ class DeleteOrgAction(BaseGithubAction):
         else:
             dict={}
 
-        user = user.strip()
+        if user == None:
+            user = ""
+        else:
+            user = user.strip()
         url = url.strip()
 
         key = user + '|' + url

--- a/actions/delete_registered_org.yaml
+++ b/actions/delete_registered_org.yaml
@@ -12,5 +12,5 @@ parameters:
     description: "base API url."
   user:
     type: "string"
-    required: true
+    required: false
     description: "User / organization name."

--- a/actions/list_orgs.py
+++ b/actions/list_orgs.py
@@ -13,9 +13,15 @@ class ListOrgsAction(BaseGithubAction):
         if base_url == None:
             self._reset(user)
         else:
-            self._reset(user+'|'+base_url)
-        user = self._client.get_user(user)
+            if user != None:
+                self._reset(user+'|'+base_url)
+            else:
+                self._reset('|'+base_url)
 
+        if user != None:
+            user = self._client.get_user(user)
+        else:
+            user = self._client.get_user()
         kwargs = {}
 
         orgs = user.get_orgs(**kwargs)

--- a/actions/list_orgs.yaml
+++ b/actions/list_orgs.yaml
@@ -9,7 +9,7 @@ parameters:
   user:
     type: "string"
     description: "User name."
-    required: true
+    required: false
   base_url:
     type: "string"
     description: "GitHub API url, include /api/v3 for GitHub Enterprise."

--- a/actions/register_org.py
+++ b/actions/register_org.py
@@ -20,8 +20,11 @@ class AddOrgAction(BaseGithubAction):
             dict=json.loads(gitorgs.value)
         else:
             dict={}
-        
-        user = user.strip()
+
+        if user == None:
+            user = ""
+        else: 
+            user = user.strip()
         url = (url or '').strip()
 
         if len(url) == 0:

--- a/actions/register_org.yaml
+++ b/actions/register_org.yaml
@@ -23,7 +23,7 @@ parameters:
     description: "API token for a member of the organization"
   user:
     type: "string"
-    required: true
+    required: false
     description: "User / organization name."
   repositories:
     type: "array"


### PR DESCRIPTION
This PR makes the user / org name optional in register_org and list_orgs actions.  The list of orgs for a personal access token can be get by:
1. register_org action without user / org parameter
1. list_orgs action without user / org parameter